### PR TITLE
Add GFF3 file format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/
 
 data/distances
 data/processed/*
+.DS_Store

--- a/scripts/annotate.py
+++ b/scripts/annotate.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+"""
+Unified genome annotation script supporting multiple file formats.
+
+Supports:
+- GenBank (.gb, .gbk, .genbank)
+- GFF3 (.gff, .gff3) with reference FASTA
+
+Annotates bacterial genomes with promoter regulatory elements using PromoterAtlas.
+"""
+
+import argparse
+from pathlib import Path
+import torch
+
+from promoter_atlas.models.promoter_segmenter import PromoterSegmenter
+from promoter_atlas.annotation.annotator import annotate_records
+from promoter_atlas.io import (
+    detect_format,
+    load_genbank,
+    save_genbank,
+    load_gff3,
+    save_gff3,
+    extract_promoter_regions_genbank,
+    extract_promoter_regions_gff
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Annotate promoter elements in bacterial genomes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Annotate GenBank file
+  python annotate.py --input genome.gb --output annotated.gb
+
+  # Annotate GFF3 file (requires reference FASTA)
+  python annotate.py --input genome.gff3 --reference genome.fasta --output annotated.gff3
+
+  # Specify format explicitly
+  python annotate.py --input genome.gff --reference genome.fna --output annotated.gff --format gff3
+
+  # Customize upstream region length
+  python annotate.py --input genome.gb --output annotated.gb --upstream-length 300
+"""
+    )
+
+    # Required arguments
+    parser.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="Path to input genome file (GenBank or GFF3)"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Path to save annotated genome file"
+    )
+
+    # Format arguments
+    parser.add_argument(
+        "--format",
+        choices=["genbank", "gff3", "auto"],
+        default="auto",
+        help="Input file format (default: auto-detect from extension)"
+    )
+    parser.add_argument(
+        "--reference",
+        type=str,
+        help="Reference FASTA file (required for GFF3 input)"
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=["genbank", "gff3", "auto"],
+        default="auto",
+        help="Output file format (default: same as input)"
+    )
+
+    # Model arguments
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default="trained_weights/segmentation/promoteratlas-annotation.pt",
+        help="Path to PromoterAtlas segmentation model weights"
+    )
+
+    # Annotation parameters
+    parser.add_argument(
+        "--upstream-length",
+        type=int,
+        default=200,
+        help="Length of upstream region to extract (bp, default: 200)"
+    )
+    parser.add_argument(
+        "--min-intergenic-length",
+        type=int,
+        default=5,
+        help="Minimum intergenic distance (bp, default: 5)"
+    )
+    parser.add_argument(
+        "--min-segment-length",
+        type=int,
+        default=4,
+        help="Minimum length for regulatory segments (bp, default: 4)"
+    )
+
+    # Device argument
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default=None,
+        help="Device to use for inference (default: auto-detect)"
+    )
+
+    args = parser.parse_args()
+
+    # Detect input format
+    if args.format == "auto":
+        try:
+            input_format = detect_format(args.input)
+            print(f"Detected input format: {input_format}")
+        except ValueError as e:
+            parser.error(str(e))
+    else:
+        input_format = args.format
+
+    # Validate GFF3 requirements
+    if input_format == "gff3" and not args.reference:
+        parser.error("--reference FASTA file is required when using GFF3 input")
+
+    # Determine output format
+    if args.output_format == "auto":
+        output_format = input_format
+    else:
+        output_format = args.output_format
+
+    # Set device
+    if args.device:
+        device = torch.device(args.device)
+    else:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {device}")
+
+    # Load model
+    print(f"Loading PromoterAtlas model from {args.model_path}")
+    model = PromoterSegmenter.from_pretrained(args.model_path)
+    model = model.to(device)
+
+    # Load genome based on format
+    print(f"Loading {input_format.upper()} file: {args.input}")
+    if input_format == "genbank":
+        records = load_genbank(args.input)
+        promoter_regions = extract_promoter_regions_genbank(
+            records,
+            upstream_length=args.upstream_length,
+            min_intergenic_length=args.min_intergenic_length
+        )
+    elif input_format == "gff3":
+        records, _ = load_gff3(args.input, args.reference)
+        promoter_regions = extract_promoter_regions_gff(
+            records,
+            upstream_length=args.upstream_length,
+            min_intergenic_length=args.min_intergenic_length
+        )
+    else:
+        parser.error(f"Unsupported format: {input_format}")
+
+    print(f"Loaded {len(records)} record(s)")
+    print(f"Extracted {len(promoter_regions)} promoter regions")
+
+    if not promoter_regions:
+        print("WARNING: No promoter regions found. Check your input file has CDS features.")
+        print("Saving original records without annotations.")
+    else:
+        # Annotate records
+        records, feature_count = annotate_records(
+            records,
+            promoter_regions,
+            model,
+            device=str(device),
+            min_segment_length=args.min_segment_length
+        )
+        print(f"Added {feature_count} regulatory features")
+
+    # Save output
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Saving annotated {output_format.upper()} to: {output_path}")
+    if output_format == "genbank":
+        save_genbank(records, args.output)
+    elif output_format == "gff3":
+        save_gff3(records, args.output, include_fasta=False)
+    else:
+        parser.error(f"Unsupported output format: {output_format}")
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/annotate_genbank.py
+++ b/scripts/annotate_genbank.py
@@ -1,60 +1,39 @@
 #!/usr/bin/env python
-import argparse
+"""
+DEPRECATED: This script is deprecated in favor of the unified annotate.py script.
+
+This wrapper maintains backward compatibility but will be removed in a future version.
+Please use: python scripts/annotate.py --input your_genome.gb --output annotated.gb
+
+For GenBank files, the new script works identically to this one.
+"""
+
+import warnings
+import sys
 from pathlib import Path
-import torch
-from Bio import SeqIO
 
-from promoter_atlas.models.promoter_segmenter import PromoterSegmenter
-from promoter_atlas.annotation.genbank_annotator import annotate_genbank
+# Issue deprecation warning
+warnings.warn(
+    "\n" + "="*70 + "\n"
+    "DEPRECATION WARNING: annotate_genbank.py is deprecated.\n"
+    "Please use 'annotate.py' instead:\n\n"
+    "  python scripts/annotate.py --input genome.gb --output annotated.gb\n\n"
+    "This wrapper will be removed in a future version.\n"
+    "="*70,
+    DeprecationWarning,
+    stacklevel=2
+)
 
-def main():
-    parser = argparse.ArgumentParser(description="Annotate promoter elements in a GenBank file")
-    parser.add_argument("--input", type=str, required=True,
-                      help="Path to GenBank file or accession number")
-    parser.add_argument("--output", type=str, required=True,
-                      help="Path to save annotated GenBank file")
-    parser.add_argument("--model-path", type=str, 
-                      default="trained_weights/segmentation/promoteratlas-annotation.pt",
-                      help="Path to segmentation model weights")
-    args = parser.parse_args()
-    
-    # Set device
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    print(f"Using device: {device}")
-    
-    # Load model
-    print(f"Loading model from {args.model_path}")
-    model = PromoterSegmenter.from_pretrained(args.model_path)
-    model = model.to(device)
-    
-    # Load GenBank file or accession
-    input_path = Path(args.input)
-    print(f"Loading GenBank file: {input_path}")
-    with open(input_path) as f:
-        records = list(SeqIO.parse(f, "genbank"))
+# Add scripts directory to path
+scripts_dir = Path(__file__).parent
+sys.path.insert(0, str(scripts_dir))
 
-    if not records:
-        raise ValueError(f"No records found in {args.input}")
-    
-    # Process each record
-    annotated_records = []
-    total_features = 0
-    
-    for record in records:
-        annotated_record, feature_count = annotate_genbank(
-            record, model, device)
-        annotated_records.append(annotated_record)
-        total_features += feature_count
-    
-    # Save output
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    with open(output_path, 'w') as f:
-        SeqIO.write(annotated_records, f, "genbank")
-    
-    print(f"Processed {len(records)} record(s), added {total_features} features")
-    print(f"Annotated GenBank saved to: {output_path}")
+# Import and run the unified annotate script
+import annotate
+
+# Force format to genbank if not specified
+if "--format" not in sys.argv:
+    sys.argv.extend(["--format", "genbank"])
 
 if __name__ == "__main__":
-    main()
+    annotate.main()

--- a/src/promoter_atlas/annotation/__init__.py
+++ b/src/promoter_atlas/annotation/__init__.py
@@ -1,0 +1,10 @@
+"""Genome annotation utilities."""
+
+from .genbank_annotator import annotate_genbank
+from .annotator import annotate_records, LABEL_MAP
+
+__all__ = [
+    'annotate_genbank',
+    'annotate_records',
+    'LABEL_MAP',
+]

--- a/src/promoter_atlas/annotation/annotator.py
+++ b/src/promoter_atlas/annotation/annotator.py
@@ -1,0 +1,214 @@
+"""Format-agnostic genome annotation utilities."""
+
+from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqRecord import SeqRecord
+from typing import List, Dict, Any
+import torch
+from promoter_atlas.utils.genomics import sequence_to_onehot
+
+# Mapping of numeric labels to regulatory elements
+LABEL_MAP = {
+    1: "RBS",
+    2: "σ70 / σ38 promoter -10 element",
+    3: "σ70 / σ38 promoter -35 element",
+    4: "σ54 promoter -12 element",
+    5: "σ54 promoter -24 element",
+    6: "σ32 promoter -10 element",
+    7: "σ32 promoter -35 element",
+    8: "σ28 promoter -10 element",
+    9: "σ28 promoter -35 element",
+    10: "σ24 promoter -10 element",
+    11: "σ24 promoter -35 element",
+}
+
+
+def find_consecutive_segments(predictions: List[int], min_length: int = 4) -> List[Dict[str, Any]]:
+    """
+    Find segments with at least min_length consecutive same predictions.
+
+    Args:
+        predictions: List of predicted class labels
+        min_length: Minimum consecutive length for a valid segment
+
+    Returns:
+        List of segment dictionaries with 'label', 'start', 'end'
+    """
+    segments = []
+    current_label = predictions[0]
+    current_start = 0
+    current_length = 1
+
+    for i in range(1, len(predictions)):
+        if predictions[i] == current_label:
+            current_length += 1
+        else:
+            if current_length >= min_length and current_label != 0:  # Ignore label 0
+                segments.append({
+                    'label': current_label,
+                    'start': current_start,
+                    'end': i
+                })
+            current_label = predictions[i]
+            current_start = i
+            current_length = 1
+
+    # Check last segment
+    if current_length >= min_length and current_label != 0:
+        segments.append({
+            'label': current_label,
+            'start': current_start,
+            'end': len(predictions)
+        })
+
+    # Apply co-occurrence rules
+    return apply_cooccurrence_rules(segments)
+
+
+def apply_cooccurrence_rules(segments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Apply co-occurrence rules for promoter element pairs.
+
+    Certain promoter elements must appear together (e.g., -10 and -35 elements).
+    This function filters segments to ensure paired elements both exist.
+
+    Args:
+        segments: List of segment dictionaries
+
+    Returns:
+        Filtered list of segments where paired elements both exist
+    """
+    # Define pairs that must co-occur
+    required_pairs = [(2, 3), (4, 5), (6, 7), (8, 9), (10, 11)]
+
+    # Get existing labels
+    existing_labels = set(segment['label'] for segment in segments)
+
+    # Identify which segments to keep
+    segments_to_keep = []
+
+    for segment in segments:
+        label = segment['label']
+        keep_segment = True
+
+        # Check if this label is part of a required pair
+        for pair in required_pairs:
+            if label in pair:
+                # Find the partner label
+                partner_label = pair[1] if label == pair[0] else pair[0]
+
+                # If partner doesn't exist, mark for removal
+                if partner_label not in existing_labels:
+                    keep_segment = False
+                    break
+
+        if keep_segment:
+            segments_to_keep.append(segment)
+
+    return segments_to_keep
+
+
+def create_regulatory_feature(
+    segment: Dict[str, Any],
+    promoter: Dict[str, Any]
+) -> SeqFeature:
+    """
+    Create a SeqFeature for a regulatory element.
+
+    Args:
+        segment: Dictionary with 'label', 'start', 'end'
+        promoter: Dictionary with promoter metadata
+
+    Returns:
+        BioPython SeqFeature object, or None if invalid
+    """
+    label = segment['label']
+    if label not in LABEL_MAP:
+        return None
+
+    if promoter['strand'] == '+':
+        feature_start = promoter['start'] + segment['start']
+        feature_end = promoter['start'] + segment['end']
+        strand = 1
+    else:
+        # For reverse strand, count from the end
+        feature_start = promoter['end'] - segment['end']
+        feature_end = promoter['end'] - segment['start']
+        strand = -1
+
+    feature = SeqFeature(
+        FeatureLocation(feature_start, feature_end, strand=strand),
+        type="regulatory",
+        qualifiers={
+            "regulatory_class": LABEL_MAP[label],
+            "note": f"Predicted by PromoterAtlas segmentation model for gene {promoter['locus_tag']}"
+        }
+    )
+
+    return feature
+
+
+def annotate_records(
+    records: List[SeqRecord],
+    promoter_regions: List[Dict[str, Any]],
+    model,
+    device: str = 'cpu',
+    min_segment_length: int = 4
+) -> tuple[List[SeqRecord], int]:
+    """
+    Annotate genome records with promoter elements.
+
+    This function is format-agnostic and works with any SeqRecord objects.
+
+    Args:
+        records: List of SeqRecord objects to annotate
+        promoter_regions: List of promoter region dictionaries from extraction
+        model: PromoterSegmenter model
+        device: Device to run inference on ('cpu' or 'cuda')
+        min_segment_length: Minimum length for regulatory segments
+
+    Returns:
+        Tuple of (annotated_records, feature_count)
+    """
+    print(f"Annotating {len(records)} record(s) with {len(promoter_regions)} promoter regions")
+
+    if not promoter_regions:
+        print("No promoter regions found")
+        return records, 0
+
+    feature_count = 0
+    model.eval()
+
+    # Create a mapping of record_id to record for efficient lookup
+    record_map = {record.id: record for record in records}
+
+    # Process each promoter region
+    for promoter in promoter_regions:
+        # Convert sequence to one-hot encoding
+        x = sequence_to_onehot(promoter['sequence']).unsqueeze(0).to(device)
+
+        # Get model predictions
+        with torch.no_grad():
+            logits = model(x)
+            predictions = logits.argmax(dim=1)[0].cpu().tolist()
+
+        # Find consecutive segment predictions
+        segments = find_consecutive_segments(predictions, min_length=min_segment_length)
+
+        # Create and add features to the corresponding record
+        record_id = promoter.get('record_id', records[0].id)
+        if record_id in record_map:
+            record = record_map[record_id]
+
+            for segment in segments:
+                feature = create_regulatory_feature(segment, promoter)
+                if feature:
+                    record.features.append(feature)
+                    feature_count += 1
+
+    # Sort features by position for each record
+    for record in records:
+        record.features.sort(key=lambda x: x.location.start)
+
+    print(f"Added {feature_count} regulatory features")
+
+    return records, feature_count

--- a/src/promoter_atlas/io/__init__.py
+++ b/src/promoter_atlas/io/__init__.py
@@ -1,0 +1,24 @@
+"""I/O utilities for different genome annotation formats."""
+
+from .formats import detect_format, validate_format
+from .genbank_io import (
+    load_genbank,
+    save_genbank,
+    extract_promoter_regions_genbank
+)
+from .gff_io import (
+    load_gff3,
+    save_gff3,
+    extract_promoter_regions_gff
+)
+
+__all__ = [
+    'detect_format',
+    'validate_format',
+    'load_genbank',
+    'save_genbank',
+    'extract_promoter_regions_genbank',
+    'load_gff3',
+    'save_gff3',
+    'extract_promoter_regions_gff',
+]

--- a/src/promoter_atlas/io/formats.py
+++ b/src/promoter_atlas/io/formats.py
@@ -1,0 +1,57 @@
+"""File format detection and validation utilities."""
+
+from pathlib import Path
+from typing import Optional
+
+
+def detect_format(filepath: str) -> str:
+    """
+    Detect file format from file extension.
+
+    Args:
+        filepath: Path to the file
+
+    Returns:
+        Format string: 'genbank', 'gff3', or 'fasta'
+
+    Raises:
+        ValueError: If format cannot be determined
+    """
+    path = Path(filepath)
+    suffix = path.suffix.lower()
+
+    # GenBank formats
+    if suffix in ['.gb', '.gbk', '.genbank']:
+        return 'genbank'
+
+    # GFF formats
+    if suffix in ['.gff', '.gff3']:
+        return 'gff3'
+
+    # FASTA formats
+    if suffix in ['.fa', '.fasta', '.fna', '.ffn']:
+        return 'fasta'
+
+    raise ValueError(
+        f"Cannot detect format from file extension '{suffix}'. "
+        f"Supported extensions: .gb, .gbk, .genbank (GenBank), "
+        f".gff, .gff3 (GFF3), .fa, .fasta, .fna, .ffn (FASTA)"
+    )
+
+
+def validate_format(filepath: str, expected_format: str) -> bool:
+    """
+    Validate that a file matches the expected format.
+
+    Args:
+        filepath: Path to the file
+        expected_format: Expected format ('genbank', 'gff3', or 'fasta')
+
+    Returns:
+        True if format matches, False otherwise
+    """
+    try:
+        detected = detect_format(filepath)
+        return detected == expected_format
+    except ValueError:
+        return False

--- a/src/promoter_atlas/io/genbank_io.py
+++ b/src/promoter_atlas/io/genbank_io.py
@@ -1,0 +1,176 @@
+"""GenBank file I/O utilities."""
+
+from pathlib import Path
+from typing import List, Dict, Any
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+
+
+def load_genbank(filepath: str) -> List[SeqRecord]:
+    """
+    Load GenBank file(s).
+
+    Args:
+        filepath: Path to GenBank file
+
+    Returns:
+        List of SeqRecord objects
+
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If no records found or parsing fails
+    """
+    path = Path(filepath)
+    if not path.exists():
+        raise FileNotFoundError(f"GenBank file not found: {filepath}")
+
+    with open(path) as f:
+        records = list(SeqIO.parse(f, "genbank"))
+
+    if not records:
+        raise ValueError(f"No GenBank records found in {filepath}")
+
+    return records
+
+
+def save_genbank(records: List[SeqRecord], filepath: str) -> None:
+    """
+    Save SeqRecord(s) to GenBank file.
+
+    Args:
+        records: List of SeqRecord objects
+        filepath: Output path
+
+    Raises:
+        ValueError: If records list is empty
+    """
+    if not records:
+        raise ValueError("Cannot save empty records list")
+
+    path = Path(filepath)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, 'w') as f:
+        SeqIO.write(records, f, "genbank")
+
+
+def extract_promoter_regions_genbank(
+    records: List[SeqRecord],
+    upstream_length: int = 200,
+    min_intergenic_length: int = 5
+) -> List[Dict[str, Any]]:
+    """
+    Extract promoter regions from GenBank records.
+
+    Args:
+        records: List of GenBank SeqRecord objects
+        upstream_length: Length of upstream region to extract (default: 200bp)
+        min_intergenic_length: Minimum intergenic distance (default: 5bp)
+
+    Returns:
+        List of dictionaries containing promoter information:
+            - organism: Organism name
+            - location: BioPython FeatureLocation object
+            - sequence: DNA sequence string
+            - locus_tag: Locus tag
+            - gene: Gene name (if available)
+            - strand: '+' or '-'
+            - start: Start position
+            - end: End position
+            - record_id: Record ID from which region was extracted
+    """
+    promoter_regions = []
+
+    for record in records:
+        features = record.features
+        sequence = record.seq
+        organism = record.annotations.get('organism', 'Unknown')
+        record_id = record.id
+
+        # Extract forward strand genes
+        genes_forward = []
+        for feature in features:
+            if (feature.location.strand == 1 and
+                feature.type == "CDS" and
+                "locus_tag" in feature.qualifiers):
+                gene_name = feature.qualifiers.get("gene", [None])[0]
+                genes_forward.append([
+                    feature.location,
+                    feature.qualifiers["locus_tag"][0],
+                    gene_name
+                ])
+
+        # Extract reverse strand genes
+        genes_reverse = []
+        for feature in features:
+            if (feature.location.strand == -1 and
+                feature.type == "CDS" and
+                "locus_tag" in feature.qualifiers):
+                gene_name = feature.qualifiers.get("gene", [None])[0]
+                genes_reverse.append([
+                    feature.location,
+                    feature.qualifiers["locus_tag"][0],
+                    gene_name
+                ])
+
+        # Process forward strand
+        last_end_forward = 0
+        for location, locus_tag, gene_name in genes_forward:
+            start = location.start
+            end = location.end
+
+            # Skip if too close to sequence start
+            if start < upstream_length:
+                continue
+
+            # Check intergenic distance
+            if start - last_end_forward >= min_intergenic_length:
+                # Extract upstream sequence
+                prom_seq = sequence[start - upstream_length:start]
+
+                promoter_regions.append({
+                    'organism': organism,
+                    'location': location,
+                    'sequence': str(prom_seq),
+                    'locus_tag': locus_tag,
+                    'gene': gene_name,
+                    'strand': '+',
+                    'start': start - upstream_length,
+                    'end': start,
+                    'record_id': record_id
+                })
+
+            last_end_forward = end
+
+        # Process reverse strand (sorted from end to start)
+        last_end_reverse = len(sequence)
+        genes_reverse = genes_reverse[::-1]
+
+        for location, locus_tag, gene_name in genes_reverse:
+            start = location.start
+            end = location.end
+
+            # Skip if too close to sequence end
+            if len(sequence) - end < upstream_length:
+                continue
+
+            # Check intergenic distance
+            if last_end_reverse - end >= min_intergenic_length:
+                # Extract downstream sequence and reverse complement
+                prom_seq = sequence[end:end + upstream_length].reverse_complement()
+
+                promoter_regions.append({
+                    'organism': organism,
+                    'location': location,
+                    'sequence': str(prom_seq),
+                    'locus_tag': locus_tag,
+                    'gene': gene_name,
+                    'strand': '-',
+                    'start': end,
+                    'end': end + upstream_length,
+                    'record_id': record_id
+                })
+
+            last_end_reverse = start
+
+    return promoter_regions

--- a/src/promoter_atlas/io/gff_io.py
+++ b/src/promoter_atlas/io/gff_io.py
@@ -1,0 +1,208 @@
+"""GFF3 file I/O utilities."""
+
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+from BCBio import GFF
+
+
+def load_gff3(
+    gff_path: str,
+    fasta_path: str
+) -> tuple[List[SeqRecord], Dict[str, SeqRecord]]:
+    """
+    Load GFF3 annotation file with reference FASTA.
+
+    Args:
+        gff_path: Path to GFF3 file
+        fasta_path: Path to reference FASTA file
+
+    Returns:
+        Tuple of (annotated_records, fasta_dict)
+        - annotated_records: List of SeqRecord objects with GFF annotations
+        - fasta_dict: Dictionary mapping sequence IDs to SeqRecord objects
+
+    Raises:
+        FileNotFoundError: If files don't exist
+        ValueError: If files cannot be parsed
+    """
+    gff_file = Path(gff_path)
+    fasta_file = Path(fasta_path)
+
+    if not gff_file.exists():
+        raise FileNotFoundError(f"GFF3 file not found: {gff_path}")
+    if not fasta_file.exists():
+        raise FileNotFoundError(f"FASTA file not found: {fasta_path}")
+
+    # Load FASTA sequences
+    fasta_dict = SeqIO.to_dict(SeqIO.parse(fasta_file, "fasta"))
+
+    if not fasta_dict:
+        raise ValueError(f"No sequences found in FASTA file: {fasta_path}")
+
+    # Load GFF3 and attach sequences
+    with open(gff_file) as gff_handle:
+        records = list(GFF.parse(gff_handle, base_dict=fasta_dict))
+
+    if not records:
+        raise ValueError(f"No records found in GFF3 file: {gff_path}")
+
+    return records, fasta_dict
+
+
+def save_gff3(
+    records: List[SeqRecord],
+    gff_path: str,
+    include_fasta: bool = False
+) -> None:
+    """
+    Save SeqRecord(s) to GFF3 file.
+
+    Args:
+        records: List of SeqRecord objects with features
+        gff_path: Output GFF3 path
+        include_fasta: Whether to include FASTA sequences at end of GFF3
+
+    Raises:
+        ValueError: If records list is empty
+    """
+    if not records:
+        raise ValueError("Cannot save empty records list")
+
+    path = Path(gff_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, 'w') as gff_handle:
+        GFF.write(records, gff_handle, include_fasta=include_fasta)
+
+
+def extract_promoter_regions_gff(
+    records: List[SeqRecord],
+    upstream_length: int = 200,
+    min_intergenic_length: int = 5
+) -> List[Dict[str, Any]]:
+    """
+    Extract promoter regions from GFF3-annotated records.
+
+    Args:
+        records: List of SeqRecord objects with GFF annotations
+        upstream_length: Length of upstream region to extract (default: 200bp)
+        min_intergenic_length: Minimum intergenic distance (default: 5bp)
+
+    Returns:
+        List of dictionaries containing promoter information:
+            - organism: Organism name (from record description or 'Unknown')
+            - location: BioPython FeatureLocation object
+            - sequence: DNA sequence string
+            - locus_tag: Locus tag or gene ID
+            - gene: Gene name (if available)
+            - strand: '+' or '-'
+            - start: Start position
+            - end: End position
+            - record_id: Record ID from which region was extracted
+    """
+    promoter_regions = []
+
+    for record in records:
+        features = record.features
+        sequence = record.seq
+        organism = record.description if record.description else 'Unknown'
+        record_id = record.id
+
+        # Extract forward strand genes (CDS features)
+        genes_forward = []
+        for feature in features:
+            if feature.type in ["CDS", "gene"] and feature.location.strand == 1:
+                # Try to get locus_tag, ID, or Name
+                locus_tag = (
+                    feature.qualifiers.get("locus_tag", [None])[0] or
+                    feature.qualifiers.get("ID", [None])[0] or
+                    feature.qualifiers.get("Name", [None])[0]
+                )
+                if locus_tag:
+                    gene_name = feature.qualifiers.get("Name", [None])[0]
+                    genes_forward.append([
+                        feature.location,
+                        locus_tag,
+                        gene_name
+                    ])
+
+        # Extract reverse strand genes
+        genes_reverse = []
+        for feature in features:
+            if feature.type in ["CDS", "gene"] and feature.location.strand == -1:
+                locus_tag = (
+                    feature.qualifiers.get("locus_tag", [None])[0] or
+                    feature.qualifiers.get("ID", [None])[0] or
+                    feature.qualifiers.get("Name", [None])[0]
+                )
+                if locus_tag:
+                    gene_name = feature.qualifiers.get("Name", [None])[0]
+                    genes_reverse.append([
+                        feature.location,
+                        locus_tag,
+                        gene_name
+                    ])
+
+        # Process forward strand
+        last_end_forward = 0
+        for location, locus_tag, gene_name in genes_forward:
+            start = int(location.start)
+            end = int(location.end)
+
+            # Skip if too close to sequence start
+            if start < upstream_length:
+                continue
+
+            # Check intergenic distance
+            if start - last_end_forward >= min_intergenic_length:
+                # Extract upstream sequence
+                prom_seq = sequence[start - upstream_length:start]
+
+                promoter_regions.append({
+                    'organism': organism,
+                    'location': location,
+                    'sequence': str(prom_seq),
+                    'locus_tag': locus_tag,
+                    'gene': gene_name,
+                    'strand': '+',
+                    'start': start - upstream_length,
+                    'end': start,
+                    'record_id': record_id
+                })
+
+            last_end_forward = end
+
+        # Process reverse strand (sorted from end to start)
+        last_end_reverse = len(sequence)
+        genes_reverse = genes_reverse[::-1]
+
+        for location, locus_tag, gene_name in genes_reverse:
+            start = int(location.start)
+            end = int(location.end)
+
+            # Skip if too close to sequence end
+            if len(sequence) - end < upstream_length:
+                continue
+
+            # Check intergenic distance
+            if last_end_reverse - end >= min_intergenic_length:
+                # Extract downstream sequence and reverse complement
+                prom_seq = sequence[end:end + upstream_length].reverse_complement()
+
+                promoter_regions.append({
+                    'organism': organism,
+                    'location': location,
+                    'sequence': str(prom_seq),
+                    'locus_tag': locus_tag,
+                    'gene': gene_name,
+                    'strand': '-',
+                    'start': end,
+                    'end': end + upstream_length,
+                    'record_id': record_id
+                })
+
+            last_end_reverse = start
+
+    return promoter_regions


### PR DESCRIPTION
Implements GFF3 support as requested in #1:
- Support for GFF3 + separate FASTA files
- Support for GFF3 with embedded ##FASTA sections (via BCBio.GFF)
- New src/promoter_atlas/io/ module with format abstraction
- Unified scripts/annotate.py with auto-format detection
- Backward-compatible deprecation of annotate_genbank.py

Features:
- Auto-detects file format from extension (.gb, .gff3, .fasta)
- Configurable upstream region length parameter
- Compatible with Prokka/Bakta/PGAP annotation pipelines
- Format-agnostic annotation logic

Closes #1